### PR TITLE
Fixed server_handler_wrapper stacking callbacks

### DIFF
--- a/worker/server_handler_wrapper.js
+++ b/worker/server_handler_wrapper.js
@@ -50,7 +50,8 @@ define(function(require, exports, module) {
             worker.sender.on("jsonalyzerCallServerResult", function onResult(e) {
                 if (e.data.id !== options.id)
                     return;
-                worker.sender.off(onResult);
+                
+                worker.sender.off("jsonalyzerCallServerResult", onResult);
 
                 var err = e.data.result[0];
                 if (err && err.code === "EFATAL") {


### PR DESCRIPTION
Due to using the wrong syntax, all worker event callbacks stacked indefinitely.